### PR TITLE
Fix coproduct_external.svg.

### DIFF
--- a/_chapters/02_category/coproduct_external.svg
+++ b/_chapters/02_category/coproduct_external.svg
@@ -13,8 +13,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:ns="&amp;#38;#38;#38;ns_ai;">
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata2853">
     <rdf:RDF>
@@ -52,7 +51,6 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1" />
   <g
-     ns:extraneous="self"
      id="g2845"
      transform="matrix(0.80243696,0,0,0.80243696,57.182648,9.227506)">
     <circle


### PR DESCRIPTION
This SVG doesn't render in Chrome, with an error """This page contains the following errors: error on line 17 at column 38: xmlns:ns: '&#38;#38;#38;ns_ai;' is not a valid URI Below is a rendering of the page up to the first error."""

`ns_ai` schema would be "http://ns.adobe.com/AdobeIllustrator/10.0/" but in this case we simply don't need it and should remove it. It isn't present in other SVG files.