### PR TITLE
chapter 3 review and edits

### DIFF
--- a/_chapters/03_monoid.md
+++ b/_chapters/03_monoid.md
@@ -31,14 +31,14 @@ The monoid operation should, like functional composition, be *associative* i.e. 
 
 ![Associativity in the color mixing operation](../03_monoid/balls_associativity.svg)
 
-When an operation is associative, it means we can use all kinds of algebraic operations to any sequence of terms (or in other words to apply equation reasoning), like for example we can replace any element with a set of elements from which it is composed, or add a term that is present at both sides of an equation and retain the equality of the existing terms.
+When an operation is associative, this means we can use all kinds of algebraic operations to any sequence of terms (or in other words to apply equation reasoning), like for example we can replace any element with a set of elements from which it is composed, or add a term that is present at both sides of an equation and retain the equality of the existing terms.
 
 ![Associativity in the color mixing operation](../03_monoid/balls_arithmetic.svg)
 
 The identity element
 ---
 
-An associative operation is not the only requirement for a structure to be considered a monoid (as opposed to a *semigroup*, which only requires associativity, but that's a separate topic for later!). Additionally, a set must feature what is called an *identity element* of a given operation, the concept of which you are already familiar from both sets and categories --- it is an element that when combined with any other element gives back that same element. Or simply $x • i = x$ and $i • x = x$ for any $x$. 
+Actually, not any (associative) operation for combining elements makes for a monoid (it makes for a *semigroup*, which is also a thing, but that's a separate topic). To be a monoid, a set must feature what is called an *identity element* of the operation, a concept of which you are already familiar from both sets and categories --- it is an element that when combined with any other element gives back that same element (not the identity but the other one). Or simply $x • i = x$ and $i • x = x$ for any $x$. 
 
 In the case of our color-mixing monoid the identity element is the white ball (or perhaps a transparent one, if we have one).
 
@@ -97,7 +97,7 @@ Formally, we can define a monoid from any set $A$, by defining an (associative) 
 Other monoid-like objects
 ===
 
-Monoid operations obey two laws --- they are *associative* and there is an *identity element*. In some cases we come across operations that also obey other laws that are also interesting. Imposing more rules to the way in which objects are combined results in the definition of other monoid-like structures.
+Monoid operations obey two laws --- they are *associative* and there is an *identity element*. In some cases we come across operations that also obey other laws that are also interesting. Imposing more (or less) rules to the way in which objects are combined results in the definition of other monoid-like structures.
 
 Commutative (abelian) monoids
 ---
@@ -141,7 +141,7 @@ And now on to symmetry groups.
 Symmetry groups and group classifications
 ===
 
-An interesting collection of groups/monoids are the groups of *symmetries* of geometric figures. Given some geometric figure, a symmetry is an action after which the figure is not displaced (e.g. it can fit into the same mold that it fitted before the action was applied).
+An interesting kind of groups/monoids are the groups of *symmetries* of geometric figures. Given some geometric figure, a symmetry is an action after which the figure is not displaced (e.g. it can fit into the same mold that it fitted before the action was applied).
 
 We won't use the balls this time, because in terms of symmetries they have just one position and hence just one action --- the identity action (which is its own reverse, by the way). So let's take this triangle, which, for our purposes, is the same as any other triangle (we are not interested in the triangle itself, but in its rotations).
 
@@ -173,9 +173,9 @@ But it gets  much simpler to grasp if we notice the following: although our grou
 
 ![The group of rotations in a triangle](../03_monoid/symmetry_rotation_cyclic.svg)
 
-Symmetry groups that have this idea of a "main" rotation, and in general, groups and monoids that have an object that is capable of generating all other objects by its repeated application, are called *cyclic groups*. In these cases, the "main" rotation is called the group's *generator*.
+Symmetry groups that have such "main" rotation, and in general, groups and monoids that have an object that is capable of generating all other objects by its repeated application, are called *cyclic groups*. The "main" rotation is called the group's *generator*.
 
-All rotation groups are cyclic groups. Another example of a cyclic group is, indeed, the natural numbers under addition. Here we may use $+1$ or $-1$ as generators.
+All rotation groups are cyclic groups. Another example of a cyclic group is, yes, the natural numbers under addition. Here we may use $+1$ or $-1$ as generators.
 
 ![The group of numbers under addition](../03_monoid/numbers_cyclic.svg)
 
@@ -244,7 +244,7 @@ We get the set of elements of the new group by taking *the Cartesian product* of
 
 ![Two trivial groups](../03_monoid/groups_product_four.svg)
 
-The *actions* of a product group are comprised of the actions of the first group, combined with the actions of the second, where each action is applied only on the element that is a member of its original group, leaving the other element unchanged.
+And the *actions* of a product group are comprised of the actions of the first group, combined with the actions of the second, where each action is applied only on the element that is a member of its original group, leaving the other element unchanged.
 
 ![Klein four](../03_monoid/klein_four_as_product.svg)
 
@@ -561,7 +561,7 @@ The set of generators and laws that defines a given group is called the *present
 Interlude: Free monoids
 ---
 
-We saw how picking a different selection of laws gives rise to various types of monoids. But what monoids would we get if we picked no laws at all? These monoids (we get a different one depending on the set we picked) are called *free monoids*. The word "free" is used in the sense that once you have the set, you can upgrade it to a monoid for free (i.e. without having to define anything else).
+We saw how picking a different selection of laws gives rise to various types of monoids. But what monoids would we get if we pick no laws at all? These monoids (we get a different one depending on the set we pick) are called *free monoids*. The word "free" is used in the sense that once you have the set, you can upgrade it to a monoid for free (i.e. without having to define anything else).
 
 If you revisit the previous section you will notice that we already saw one such monoid. The free monoid with just one generator is isomorphic to the monoid of integers.
 

--- a/_chapters/03_monoid.md
+++ b/_chapters/03_monoid.md
@@ -6,7 +6,7 @@ title: Monoids
 Monoids etc
 ===
 
-Since we are done with categories, let's look at some other structures that are also interesting --- monoids. Like categories, monoids/groups are also abstract systems consisting of set of elements and operations for manipulating these elements, however the operations look different than the operations we have for categories. Let's see them.
+Since we are done with categories, let's look at some other structures that are also interesting --- monoids. Like categories, monoids/groups are abstract systems consisting of set of elements and operations for manipulating these elements, however the operations look different than the operations we have for categories. Let's see them.
 
 What are monoids
 ===
@@ -26,18 +26,18 @@ You can probably think of other ways to define a similar operation. This will he
 Associativity
 ---
 
-The monoid operation should, like functional composition, be *associative* i.e. applying it on the same number of elements in a different order should make no difference.
+The monoid operation should, like functional composition, be *associative* i.e. the way in which elements are grouped when applying the operation does not make any difference.
 
 ![Associativity in the color mixing operation](../03_monoid/balls_associativity.svg)
 
-When an operation is associative, this means we can use all kinds of algebraic operations to any sequence of terms (or in other words to apply equation reasoning), like for example we can replace any element with a set of elements from which it is composed of, or add a term that is present at both sides of an equation and retaining the equality of the existing terms.
+When an operation is associative, it means we can use all kinds of algebraic operations to any sequence of terms (or in other words to apply equation reasoning), like for example we can replace any element with a set of elements from which it is composed, or add a term that is present at both sides of an equation and retain the equality of the existing terms.
 
 ![Associativity in the color mixing operation](../03_monoid/balls_arithmetic.svg)
 
 The identity element
 ---
 
-Actually, not any (associative) operation for combining elements makes the balls form a monoid (it makes them form a *semigroup*, which is also a thing, but that's a separate topic). To be a monoid, a set must feature what is called an *identity element* of a given operation, the concept of which you are already familiar from both sets and categories --- it is an element that when combined with any other element gives back that same element (not the identity but the other one). Or simply $x • i = x$ and $i • x = x$ for any $x$. 
+An associative operation is not the only requirement for a structure to be considered a monoid (as opposed to a *semigroup*, which only requires associativity, but that's a separate topic for later!). Additionally, a set must feature what is called an *identity element* of a given operation, the concept of which you are already familiar from both sets and categories --- it is an element that when combined with any other element gives back that same element. Or simply $x • i = x$ and $i • x = x$ for any $x$. 
 
 In the case of our color-mixing monoid the identity element is the white ball (or perhaps a transparent one, if we have one).
 
@@ -81,7 +81,7 @@ Monoid operations in terms of set theory
 
 We now know what the monoid operation is, and we even saw some simple examples. However, we never defined the monoid rule/operation formally i.e. using the language of set theory with which we defined everything else. Can we do that? Of course we can --- everything can be defined in terms of sets. 
 
-We said that a monoid consists of two things a set (let's call it $A$) and a monoid operation that acts on that set. Since $A$ is already defined in set theory (because it is just a set), all we have to do is define the monoid operation.
+We said that a monoid consists of two things: a set (let's call it $A$), and a monoid operation that acts on that set. Since $A$ is already defined in set theory (because it is just a set), all we have to do is define the monoid operation.
 
 Defining the operation is not hard at all. Actually, we have already done it for the operation $+$ --- in chapter 2, we said that *addition* can be represented in set theory as a function that accepts a product of two numbers and returns a number (formally $+: \mathbb{Z} \times \mathbb{Z} \to \mathbb{Z}$).
 
@@ -96,7 +96,7 @@ Formally, we can define a monoid from any set $A$, by defining an (associative) 
 Other monoid-like objects
 ===
 
-Monoid operations obey two laws --- they are *associative* and there is an *identity element*. In some cases we come across operations that also obey other laws that are also interesting. Imposing more (or less) rules to the way in which (elements) objects are combined results in the definition of other monoid-like structures.
+Monoid operations obey two laws --- they are *associative* and there is an *identity element*. In some cases we come across operations that also obey other laws that are also interesting. Imposing more rules to the way in which objects are combined results in the definition of other monoid-like structures.
 
 Commutative (abelian) monoids
 ---
@@ -116,31 +116,31 @@ All monoids that we examined so far are also *commutative*. We will see some non
 Groups
 ---
 
-A group is a monoid such that for each of its elements, there is another element which is the so called "inverse" of the first one  where the element and its inverse cancel each other out when applied one after the other. Plain-English definitions like this make you appreciate mathematical formulas more --- formally we say that for all elements $x$, there must exist $x'$ such that $x • x' = i$ ( where $i$ is the identity element).
+A group is a monoid such that for each of its elements, there is another element which is the so called "inverse" of the first one  where the element and its inverse cancel each other out when applied one after the other. Plain-English definitions like this make you appreciate mathematical formulas more --- formally we say that for all elements $x$, there must exist $x'$ such that $x • x' = i$ (where $i$ is the identity element).
 
-If we view *monoids* as a means of modeling the effect of applying a set of (associative) actions, we use *groups* to model the effects of actions are also *reversible*.
+If we view *monoids* as a means of modeling the effect of applying a set of (associative) actions, we use *groups* to model the effects of actions which are also *reversible*.
 
 A nice example of a monoid that we covered that is also a group is the set of integers under addition. The inverse of each number is its opposite number (positive numbers' inverse are negatives and vice versa). The above formula, then, becomes $x + (-x) = 0$
 
-The study of groups is a field that is much bigger than the theory of monoids (and perhaps bigger than category theory itself). And one of its the biggest branches is the study of the "symmetry groups" which we will look into next.
+The study of groups is a field that is much bigger than the theory of monoids (and perhaps bigger than category theory itself). And one of its biggest branches is the study of "symmetry groups" which we will look into next.
 
 Summary
 ---
 
-But before that, just a quick note --- the algebraic structures that we saw can be summarized based on the laws that define them in this table.
+Before we move on --- the algebraic structures that we saw above can be summarized based on the laws that define them in this table:
 
-| | Semigroups | Monoids | Groups |
-|---| ---             | ---        |
-|Associativity| X | X | X |
-|Identity| | X | X |
-|Invertability | |  | X |
+|               | Semigroups    | Monoids   | Groups    |
+|---            | ---           | ---       | ---       |
+|Associativity  | X             | X         | X         |
+|Identity       |               | X         | X         |
+|Invertability  |               |           | X         |
 
-And now for the symmetry groups.
+And now on to symmetry groups.
 
 Symmetry groups and group classifications
 ===
 
-An interesting kinds of groups/monoids are the groups of *symmetries* of geometric figures. Given some geometric figure, a symmetry is an action after which the figure is not displaced (e.g. it can fit into the same mold that it fit before the action was applied).
+An interesting collection of groups/monoids are the groups of *symmetries* of geometric figures. Given some geometric figure, a symmetry is an action after which the figure is not displaced (e.g. it can fit into the same mold that it fitted before the action was applied).
 
 We won't use the balls this time, because in terms of symmetries they have just one position and hence just one action --- the identity action (which is its own reverse, by the way). So let's take this triangle, which, for our purposes, is the same as any other triangle (we are not interested in the triangle itself, but in its rotations).
 
@@ -153,7 +153,7 @@ Let's first review the group of ways in which we can rotate our triangle i.e. it
 
 ![The group of rotations in a triangle](../03_monoid/symmetry_rotation.svg)
 
-Connecting the dots (or the triangles in this case) shows us that there are just two possible rotations that get us from any state of the triangle to any other one --- a *120-degree rotation* (i.e. flipping the triangle one time) and a *240-degree rotation* (i.e. flipping it two times (or equivalently, flipping it once, but in the opposite direction)). Adding the identity action of 0-degree rotation makes up for 3 rotations (objects) in total.
+Connecting the dots (or the triangles in this case) shows us that there are just two possible rotations that get us from any state of the triangle to any other one --- a *120-degree rotation* (i.e. flipping the triangle one time) and a *240-degree rotation* (i.e. flipping it twice, or equivalently, flipping it once in the opposite direction). Adding the identity action of 0-degree rotation makes up for 3 rotations (objects) in total.
 
 ![The group of rotations in a triangle](../03_monoid/symmetry_rotation_actions.svg)
 
@@ -172,9 +172,9 @@ But it gets  much simpler to grasp if we notice the following: although our grou
 
 ![The group of rotations in a triangle](../03_monoid/symmetry_rotation_cyclic.svg)
 
-Symmetry groups that have such "main" rotation, and, in general, groups and monoids that have an object that is capable of generating all other objects by its repeated application, are called *cyclic groups*. And such rotation are called the group's *generator*.
+Symmetry groups that have this idea of a "main" rotation, and in general, groups and monoids that have an object that is capable of generating all other objects by its repeated application, are called *cyclic groups*. In these cases, the "main" rotation is called the group's *generator*.
 
-All rotation groups are cyclic groups. Another example of a cyclic groups is, yes, the natural numbers under addition. Here we can use $+1$ or $-1$ as generators.
+All rotation groups are cyclic groups. Another example of a cyclic group is, indeed, the natural numbers under addition. Here we may use $+1$ or $-1$ as generators.
 
 ![The group of numbers under addition](../03_monoid/numbers_cyclic.svg)
 
@@ -186,11 +186,11 @@ For example: $1 \pmod{12} = 1$ (because $1/12 = 0$ with $1$ remainder) $2 \pmod{
 
 But $13 \pmod{12} = 1$ (as $13/12 = 1$ with $1$ remainder) $14 \pmod{12} = 2$, $15 \pmod{12} = 3$ etc. 
 
-In effect numbers "wrap around", forming a group with as many elements as it the modulus number. Like for example a group representation of modular arithmetic with modulus $3$ has 3 elements.
+In effect, numbers "wrap around" forming a group with as many elements as the modulus number. For example a group representation of modular arithmetic with modulus $3$ has 3 elements.
 
 ![The group of numbers under addition](../03_monoid/numbers_modular.svg)
 
-All cyclic groups that have the same number of elements (or that are of the *same order*) are isomorphic to each other (careful readers might notice that we haven't yet defined what a group isomorphisms are, even more careful readers might already have an idea about what it is).
+All cyclic groups that have the same number of elements (or that are of the *same order*) are isomorphic to each other (careful readers might notice that we haven't yet defined what a group isomorphism is, even more careful readers might already have an idea about what it is).
 
  For example, the group of rotations of the triangle is isomorphic to the natural numbers under the addition with modulo $3$. 
 
@@ -209,7 +209,7 @@ We already mentioned group isomorphisms, but we didn't define what they are. Let
 
 ![Group isomorphism between different representations of S3](../03_monoid/group_isomorphism.svg)
 
-As in category theory, in group theory isomorphic groups they considered instances of one and the same group. For example the one above is called $Z_3$.
+As in category theory, in group theory isomorphic groups are considered instances of one and the same group. For example the one above is called $Z_3$.
 
 Finite groups
 ---
@@ -231,38 +231,38 @@ Like $Z_3$, $Z_1$ and $Z_2$ are cyclic.
 Group/monoid products
 ===
 
-We already saw a lot of abelian groups that are also cyclic, but we didn't see any abelian groups that are not cyclic. So let's examine what those look like. This time, instead of looking into individual examples, we will present a general way for producing abelian non-cyclic groups from cyclic ones --- it is by uniting them by using *group product*.
+We already saw a lot of abelian groups that are also cyclic, but we didn't see any abelian groups that are not cyclic. So let's examine what these look like. This time, instead of looking into individual examples, we will present a general way for producing abelian non-cyclic groups from cyclic ones --- it is by uniting them by using *group product*.
 
 Given any two groups, we can combine them to create a third group, comprised of all possible pairs of elements from the two groups and of the sum of all their actions. 
 
-Let's see how the product looks like take the following two groups (which, having just two elements and one operation, are both isomorphic to $Z2$). To make it easier to imagine them, we can think of the first one as based on the vertical reflection of a figure and the second, just the horizontal reflection.
+Let's see how the resulting group looks after taking the product of the following two groups (which, having just two elements and one operation and are both isomorphic to $Z2$). To make it easier to imagine them, we can think of the first one as based on the vertical reflection of a figure and the second, the horizontal reflection.
 
 ![Two trivial groups](../03_monoid/groups_product.svg)
 
-We get set of elements of the new group by taking *the Cartesian product* of the set of the elements of the first group and the set of the element of the second one.
+We get the set of elements of the new group by taking *the Cartesian product* of the set of elements of the first group and the set of elements of the second.
 
 ![Two trivial groups](../03_monoid/groups_product_four.svg)
 
-And the *actions* of a product group are comprised of the actions of the first group, combined with the actions of the second one, where each action is applied only on the element that is a member of its corresponding group, leaving the other element unchanged.
+The *actions* of a product group are comprised of the actions of the first group, combined with the actions of the second, where each action is applied only on the element that is a member of its original group, leaving the other element unchanged.
 
 ![Klein four](../03_monoid/klein_four_as_product.svg)
 
-The product of the two groups we presented is called the *Klein four-group* and it is the simplest *non-cyclic abelian* group. 
+The product of the two groups presented is called the *Klein four-group* and it is the simplest *non-cyclic abelian* group. 
 
-Another way to present the Klein-four group is the *group of symmetries of a non-square rectangle*.
+Another way to present the Klein four-group is the *group of symmetries of a non-square rectangle*.
 
 ![Klein four](../03_monoid/klein_four.svg)
 
 **Task:** Show that the two representations are isomorphic.
 
-The Klein-four group is *non-cyclic* (because there are not one, but two generators) --- vertical and horizontal spin. It is, however, still *abelian*, because the ordering of the actions still does not matter for the end results. Actually, the Klein-four group is the *smallest non-cyclic group*.
+The Klein four-group is *non-cyclic* (because there are not one, but two generators) --- vertical and horizontal spin. It is, however, still *abelian*, because the ordering of the actions still does not matter for the end result. Actually, the Klein four-group is the *smallest non-cyclic group*.
 
 Cyclic product groups
 ---
 
 Product groups are *non-cyclic*, provided that the number of elements of the groups that comprise them (or their *orders*) aren't *relatively prime* (have some GCD other than 1).
 
-If two groups have orders that aren't relatively prime, (like for example $2$ and $2$, (which are both divided by 2) as the groups that comprise Klein-four), then even if the two groups are cyclic and have just 1 generator each, their product would have 2 generators. 
+If two groups have orders that aren't relatively prime, (like for example $2$ and $2$, (which are both divided by 2) as the groups that comprise Klein four-groups), then even if the two groups are cyclic and have just 1 generator each, their product would have 2 generators.
 
 And if you combine two groups with orders that are relatively prime, (like $2$ and $3$) the resulting group would be isomorphic to a cyclic group of the same order, as the product of $Z_3$ and $Z_2$ is isomorphic to the group $Z_6$ ($Z_3 \times Z_2 \cong Z_6$)
 
@@ -273,7 +273,7 @@ This is a consequence of an ancient result, known as the *Chinese Remainder theo
 Abelian product groups
 ---
 
-Product groups are *abelian*, provided that the *groups that form them* are abelian. We can see that this is true by noticing that, although the generators are more than one, each of them acts only on its own part of the group, so they don't interfere with each other in any way.
+Product groups are *abelian*, provided that the *groups that form them* are abelian. We can see that this is true by noticing that, although there is more than one generator, each acts only on its own part of the group, and so don't interfere with any others.
 
 Fundamental theorem of Finite Abelian groups
 ---
@@ -330,7 +330,7 @@ Those two operations and their composite results in a group called $Dih3$ that i
 
 **Question:** Besides having two main actions, what is the defining factor that makes this and any other group non-abelian?
 
-Groups that represent the set of rotations and reflections of any 2D shape are called *dihedral groups*
+Groups that represent the set of rotations and reflections of any 2D shape are called *dihedral groups*.
 
 <!--
 TODO: FSM as monoids
@@ -355,20 +355,20 @@ The practice of transforming a function that takes a pair of objects to a functi
 
 It is achieved by a higher-order function. Here is how such a function might be implemented.
 
-```
+```typescript
 const curry = <A, B, C> (f:(a:A, b:B) => C) => (a:A) => (b:B) => f(a, b)
 ```
 And equally important is the opposite function, which maps a curried function to a multi-argument one, which is known as *uncurry*.
 
-```
-const uncurry = <A, B, C> (f:(a:A) => (b:B) => C) => (a:A, b:B ) => f(a)(b)
+```typescript
+const uncurry = <A, B, C> (f:(a:A) => (b:B) => C) => (a:A, b:B) => f(a)(b)
 ```
 
 There is a lot to say about these two functions, starting from the fact that its existence gives rise to an interesting relationship between the concept of a *product* and the concept of a *morphism* in category theory, called an *adjunction*. But we will cover this later. For now, we are interested in the fact the two function representations are isomorphic, formally $A\times B\to C\cong A\to B \to C$. 
 
 By the way, this isomorphism can be represented in terms of programming as well. It is equivalent to the statement that the following function always returns `true` for any arguments, 
 
-```
+```typescript
 (...args) => uncurry(curry(f(...args)) === f(...args)
 ```
 
@@ -379,7 +379,7 @@ This is one part of the isomorphism, the other part is the equivalent function f
 Monoid elements as functions/permutations
 ---
 
-Let's take a step back and examine the groups/monoids that we covered so far in the light of what we learned. We started off by representing group operation as a function from pairs. For example, the operation of a symmetric group,(let's take $Z_3$ as an example) are actions that converts two rotations to another rotation. 
+Let's take a step back and examine the groups/monoids that we covered so far in light of what we have learned. We started off by representing group operation as a function from pairs. For example, the operation of a symmetric group, (taking $Z_3$ as an example) are actions that converts two rotations to another rotation. 
 
 ![The group of rotations in a triangle - group notation](../03_monoid/symmetry_rotation_actions.svg)
 
@@ -429,7 +429,7 @@ Cayley's theorem
 
 Once we learn how to represent the elements of any monoid as permutations that also form a monoid, using currying, it isn't too surprising to learn that this constructed permutation monoid is isomorphic to the original one (the one from which it is constructed --- this is a result known as the Cayley's theorem:
 
-> Any group is isomorphic to a permutation group. 
+> Any group is isomorphic to its corresponding permutation group. 
 
 Formally, if we use $Perm$ to denote the permutation group then $Perm(A) \cong A$ for any $A$.
 
@@ -478,7 +478,9 @@ Based on this insight, can state Cayley's theorem in terms of symmetric groups i
 
 Fun fact: the study of group theory actually started by examining symmetric groups, so this theorem was actually a prerequisite for the emergence of the normal definition of groups that we all know and love (OK, at least *I* love it) --- it provided a proof that the notion described by this definition is equivalent to the already existing notion of symmetric groups.
 
-{% endif %}
+<!--
+{%endif%}
+-->
 
 Monoids as categories
 ---
@@ -497,14 +499,14 @@ But wait, if the monoids' underlying *sets* correspond to *objects* in category 
 
 The only difference between different monoids would be the number of morphisms that they have and the relationship between them.
 
-The intuition behind this representation from a category-theoretic standpoint is encompassed by the law of *closure* that monoid and group operations have and that categories lack --- it is the law stating that applying the operation (functional composition) on any two objects always yields the same object, e.g. no matter how do you flip a triangle, you'd still get a triangle. 
+The intuition behind this representation from a category-theoretic standpoint is encompassed by the law of *closure* that monoid and group operations have and that categories lack --- it is the law stating that applying the operation (functional composition) on any two objects always yields the same object, e.g. no matter how you flip a triangle, you still get a triangle. 
 
-| | Categories | Monoids | Groups 
-|---| ---             | ---        |
-|Associativity| X | X | X |
-|Identity| X | X | X |
-|Invertibility  | |  | X |
-|Closure  | | X | X |
+|                   | Categories    | Monoids   | Groups    |
+| ---               | ---           | ---       | ---       |
+| Associativity     | X             | X         | X         |
+| Identity          | X             | X         | X         |
+| Invertibility     |               |           | X         |
+| Closure           |               | X         | X         |
 
 When we view a monoid as a category, this law says that all morphisms in the category should be from one object to itself - a monoid, any monoid, can be seen as a *category with one object*. The converse is also true: any category with one object can be seen as a monoid.
 
@@ -520,7 +522,7 @@ Categories have an identity morphism for each object, so for categories with jus
 
 Categories provide a way to compose two morphisms with an appropriate type signature, and for categories with one object this means that *all morphisms should be composable* with one another. And the monoid operation does exactly that --- given any two objects (or two morphisms, if we use the categorical terminology), it creates a third.
 
-Philosophically, defining a monoid as a one-object category means corresponds to the view of monoids as a model of how a set of (associative) actions that are performed on a given object alter its state. Provided that the object's state is determined solely by the actions that are performed on it, we can leave it out of the equation and concentrate on how the actions are combined. And as per usual, the actions (and elements) can be anything, from mixing colors in paint, or adding a quantities to a given set of things etc.
+Philosophically, defining a monoid as a one-object category corresponds to the view of monoids as a model of how a set of (associative) actions that are performed on a given object alter its state. Provided that the object's state is determined solely by the actions that are performed on it, we can leave it out of the equation and concentrate on how the actions are combined. And as per usual, the actions (and elements) can be anything, from mixing colors in paint, or adding quantities to a given set of things etc.
 
 Group/monoid presentations
 ---
@@ -558,7 +560,7 @@ The set of generators and laws that defines a given group is called the *present
 Interlude: Free monoids
 ---
 
-We saw how picking a different selection of laws gives rise to different types of monoid. But what monoids would we get if we pick no laws at all? These monoids (we get a different one depending on the set we picked) are called a *free monoids* (the word "free" is used in the sense that once you have the set, you can upgrade it to a monoid for free (i.e. without having to define anything else).
+We saw how picking a different selection of laws gives rise to various types of monoids. But what monoids would we get if we picked no laws at all? These monoids (we get a different one depending on the set we picked) are called *free monoids*. The word "free" is used in the sense that once you have the set, you can upgrade it to a monoid for free (i.e. without having to define anything else).
 
 If you revisit the previous section you will notice that we already saw one such monoid. The free monoid with just one generator is isomorphic to the monoid of integers.
 
@@ -574,9 +576,9 @@ The free monoid is a special one --- each element of the free monoid over a give
 
 **Task:** Write up the laws of the color-mixing monoid.
 
-If we put out programmers' hat, we will see that the type of the free monoid under the set of generators T (which we can denote as `FreeMonoid<T>`) is isomorphic to the type `List<T>` (or `Array<T>`, if you prefer) and that the intuition behind the special property that we described above is actually very simple: keeping objects in a list allows you to convert them to any other structure i.e. when we want to perform some manipulation on a bunch of objects, but we don't know exactly what this manipulation is, we just keep a list of those objects until it's time to do it.
+If we put on our programmers' hat, we will see that the type of the free monoid under the set of generators T (which we can denote as `FreeMonoid<T>`) is isomorphic to the type `List<T>` (or `Array<T>`, if you prefer) and that the intuition behind the special property that we described above is actually very simple: keeping objects in a list allows you to convert them to any other structure i.e. when we want to perform some manipulation on a bunch of objects, but we don't know exactly what this manipulation is, we just keep a list of those objects until it's time to do it.
 
-While the intuition behind free monoids seems simple enough, the formal definition is not our cup of tea... yet, simply because we have to cover more stuff.
+While the intuition behind free monoids seems simple enough, the formal definition is not easily written... yet, simply because we have to cover more stuff.
 
-We understand that, being the most general of all monoids for a given set of generators, a free monoid can be converted to all of them. i.e. there exist a function from it to all of them. But what kind of function would that be? Tune in after a few chapters to find out.
+We understand that, being the most general of all monoids for a given set of generators, a free monoid can be converted to all of them. i.e. there exists a function from it to all of them. But what kind of function would that be? Tune in after a few chapters to find out.
 

--- a/_chapters/03_monoid.md
+++ b/_chapters/03_monoid.md
@@ -3,6 +3,7 @@ layout: default
 title: Monoids 
 ---
 
+
 Monoids etc
 ===
 


### PR DESCRIPTION
Hi!

See edits for Chapter 3. This chapter was great and was excellently paced with great visual examples. My only criticism would be that I felt like it was a bit rushed as it transitioned to introducing the CT view of Monoids (specifically the section "Groups/monoids Categorically" and thereafter). I fear you may lose people at exactly this point in the text, and it's really the most important bit.

In addition a few specifics which I'll leave as food for thought:

- The section on "Cyclic Product Groups" was quite hard to read as it starts by defining Product Groups as non-cyclic as long as their source orders are not relatively prime. I always struggle to read statements with two negations ("non-cyclic" and "not relatively prime"). I will leave it to you to think about, but I suggest something like this:

> Product groups are generally *non-cyclic* as we saw from the previous example - however there is an exception to this: where the number of elements of their component groups are *relatively prime*. [... and then describe the intuition of pairs of groups with relatively prime orders not having repeating elements and therefore can use a single generator ...] 

- The diagram "03_monoid/symmetry_reflection.svg" is missing the inverse arrows for the "reflect / flip" action.

- The code snippets for `curry` and `uncurry` I am guessing are written in TypeScript? Maybe worth mentioning this - and maybe to provide alternatives if possible (I am sure a certain crowd would love to see Haskell or Scala)

Great work and let me know your comments.

All the best
Tom