### PR TITLE
fix: compositions matched to the wrong identity functions in isomorphism definition

### DIFF
--- a/_chapters/01_set.md
+++ b/_chapters/01_set.md
@@ -363,7 +363,7 @@ Invertible functions are called *isomorphisms*. When there exists an invertible 
 
 Isomorphism means "same form" in Greek (although actually their form is the only thing which is different between two isomorphic sets).
 
-More formally, two sets $A$ and $B$ are isomorphic (or $A ≅ B$) if there exist functions $f: A \to B$ and its reverse $g: B \to A$, such that $f \circ g = ID_{A}$ and $g \circ f = ID_{A}$.
+More formally, two sets $A$ and $B$ are isomorphic (or $A ≅ B$) if there exist functions $f: A \to B$ and its reverse $g: B \to A$, such that $f \circ g = ID_{B}$ and $g \circ f = ID_{A}$.
 
 Notice how the identity function comes in handy.
 


### PR DESCRIPTION
Fixes line 366: f ∘ g should equal ID_B, not ID_A.